### PR TITLE
fix: pure mode in cached-nix-shell

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -155,6 +155,10 @@ fn args_to_inp(pwd: PathBuf, x: &Args) -> NixShellInput {
             // We want to pass SHELL by default
             // https://canva.sourcegraphcloud.com/search?q=context:global+ORIGINAL_USER_SHELL&patternType=keyword&sm=0
             "SHELL",
+            // Pass this to prevent disrupting the pure interactive shell session. Sourcing 
+            // `/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh` again could alter
+            // `$PATH`, even in pure mode. We aim to avoid this.
+            "__ETC_PROFILE_NIX_SOURCED",
         ];
         for var in whitelist {
             if let Some(val) = std::env::var_os(var) {
@@ -501,6 +505,10 @@ fn merge_env(mut env: EnvMap) -> EnvMap {
         "TZ",
         "PAGER",
         "SHLVL",
+        // Pass this to prevent disrupting the pure interactive shell session. Sourcing 
+        // `/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh` again could alter
+        // `$PATH`, even in pure mode. We aim to avoid this.
+        "__ETC_PROFILE_NIX_SOURCED",
     ];
     for var in keep {
         if let Some(vel) = std::env::var_os(var) {


### PR DESCRIPTION
## Motivation

Without this, it somehow was not hermetic, that is, the activation logic from `/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh` has always been executed resulting to the `$PATH` always prepended with Nix related directories, regardless of the mode (pure or impure).

## Testing
```
$ nix-build --no-out-link ./default.nix
...
/nix/store/j182grfq7ima3ls55djb246vdhx74hch-cached-nix-shell-0.1.5

$ /nix/store/j182grfq7ima3ls55djb246vdhx74hch-cached-nix-shell-0.1.5/bin/cached-nix-shell --pure -p bash

$ /nix/store/j182grfq7ima3ls55djb246vdhx74hch-cached-nix-shell-0.1.5/bin/cached-nix-shell --pure -p bash
[cached_nix_shell] updating cache
[cached_nix_shell] done in 3.125475375s

[cached-nix-shell:~/work/cached-nix-shell]$ echo $PATH | tr \: \\n
/nix/store/5cvi09jkz66vlp62zbqxvjybc6yn1cqh-bash-interactive-5.2-p21/bin
/nix/store/65lhhpbfnsf9b3knd4q2l49y7107fisp-clang-wrapper-16.0.6/bin
/nix/store/a4zdkdhr7wfdv55q9bv293grng7c3gf6-clang-16.0.6/bin
/nix/store/05f94jq5l6kfs9s3gyzj28y1v4xf6hfm-coreutils-9.4/bin
/nix/store/kw4s9nf86742y74xmikklpszsz3d55ig-cctools-binutils-darwin-wrapper-16.0.6-973.0.1/bin
/nix/store/rhh6yaccy499min8rffvkscq7mjjjr5z-cctools-binutils-darwin-16.0.6-973.0.1/bin
/nix/store/0wzb184kckhmggq1nlvy5xk6rykp0jl1-bash-5.2-p21/bin
/nix/store/05f94jq5l6kfs9s3gyzj28y1v4xf6hfm-coreutils-9.4/bin
/nix/store/c0k7n8dbl8afgjsa4ibr3x4fhhp0rvfs-findutils-4.9.0/bin
/nix/store/ifchcscjlmxyh3xqpykfvpn1l3081bb8-diffutils-3.10/bin
/nix/store/v5mi2yzla9d240q8jfmrav754lqr3qha-gnused-4.9/bin
/nix/store/08nb1wjqrmcr8x0g7l1p3i8j16in3606-gnugrep-3.11/bin
/nix/store/limmkmax92v8x9vsdz04qf1is4xxqjzj-gawk-5.2.2/bin
/nix/store/14v8091kj9rz92h4xy5rah2rxhv5ikpr-gnutar-1.35/bin
/nix/store/nms9gqaixp4kkk40ywp5y8kaa7w8zvmv-gzip-1.13/bin
/nix/store/8cajjvq7p99vi97vz7b4mhn0cldgfdn2-bzip2-1.0.8-bin/bin
/nix/store/axhb1ak9cqg77li19yvqv2n18aznh45z-gnumake-4.4.1/bin
/nix/store/0wzb184kckhmggq1nlvy5xk6rykp0jl1-bash-5.2-p21/bin
/nix/store/6sq1bxixlwvg32yc21zggz4451pcwjdl-patch-2.7.6/bin
/nix/store/yc5g8kxl4zz2pac3rzdmh0dfpz97kqhc-xz-5.4.5-bin/bin
/nix/store/ncbyshdl0dqgc92zp71d2sqvlax0msz8-file-5.45/bin
```

And without the fix (broken behaviour):
```
$ nix-shell --pure -p bash

[cached-nix-shell:~/work/cached-nix-shell]$ echo $PATH | tr \: \\n
/Users/oleg/.nix-profile/bin
/nix/var/nix/profiles/default/bin
/nix/store/5cvi09jkz66vlp62zbqxvjybc6yn1cqh-bash-interactive-5.2-p21/bin
/nix/store/65lhhpbfnsf9b3knd4q2l49y7107fisp-clang-wrapper-16.0.6/bin
/nix/store/a4zdkdhr7wfdv55q9bv293grng7c3gf6-clang-16.0.6/bin
/nix/store/05f94jq5l6kfs9s3gyzj28y1v4xf6hfm-coreutils-9.4/bin
/nix/store/kw4s9nf86742y74xmikklpszsz3d55ig-cctools-binutils-darwin-wrapper-16.0.6-973.0.1/bin
/nix/store/rhh6yaccy499min8rffvkscq7mjjjr5z-cctools-binutils-darwin-16.0.6-973.0.1/bin
/nix/store/0wzb184kckhmggq1nlvy5xk6rykp0jl1-bash-5.2-p21/bin
/nix/store/05f94jq5l6kfs9s3gyzj28y1v4xf6hfm-coreutils-9.4/bin
/nix/store/c0k7n8dbl8afgjsa4ibr3x4fhhp0rvfs-findutils-4.9.0/bin
/nix/store/ifchcscjlmxyh3xqpykfvpn1l3081bb8-diffutils-3.10/bin
/nix/store/v5mi2yzla9d240q8jfmrav754lqr3qha-gnused-4.9/bin
/nix/store/08nb1wjqrmcr8x0g7l1p3i8j16in3606-gnugrep-3.11/bin
/nix/store/limmkmax92v8x9vsdz04qf1is4xxqjzj-gawk-5.2.2/bin
/nix/store/14v8091kj9rz92h4xy5rah2rxhv5ikpr-gnutar-1.35/bin
/nix/store/nms9gqaixp4kkk40ywp5y8kaa7w8zvmv-gzip-1.13/bin
/nix/store/8cajjvq7p99vi97vz7b4mhn0cldgfdn2-bzip2-1.0.8-bin/bin
/nix/store/axhb1ak9cqg77li19yvqv2n18aznh45z-gnumake-4.4.1/bin
/nix/store/0wzb184kckhmggq1nlvy5xk6rykp0jl1-bash-5.2-p21/bin
/nix/store/6sq1bxixlwvg32yc21zggz4451pcwjdl-patch-2.7.6/bin
/nix/store/yc5g8kxl4zz2pac3rzdmh0dfpz97kqhc-xz-5.4.5-bin/bin
/nix/store/ncbyshdl0dqgc92zp71d2sqvlax0msz8-file-5.45/bin
```
(Note the first two lines, they should not be there in pure mode)
